### PR TITLE
#416 Added flag to build native library with 16kb page size

### DIFF
--- a/library/src/main/jni/Android.mk
+++ b/library/src/main/jni/Android.mk
@@ -22,5 +22,6 @@ LOCAL_MODULE    := glues
 LOCAL_SRC_FILES := com_panoramagl_opengl_GLUES.c
 LOCAL_LDLIBS    := -llog -lGLESv1_CM
 LOCAL_CFLAGS	:= -fopenmp
+LOCAL_LDFLAGS   += -Wl,-z,max-page-size=16384
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Starting November 1st, 2025, the ELF segments for shared libraries will have to be 16 KB aligned:
https://developer.android.com/guide/practices/page-sizes

This PR adds necessary options to arm64-v8a and x86_64 platforms, as they are the only ones that have the requirement.

Fixes #416